### PR TITLE
fix: allow a job doesn't have permissions if a workflow has empty permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Actions linter
 
 ## Policies
 
-- `job_permissions`: All jobs should have `permissions`
+- `job_permissions`: All jobs should have `permissions` unless workflow's `permissions` is empty `{}`
   - Why: For least privilege
 - `workflow_secrets`: Workflow should not set secrets to environment variables
   - How to fix: set secrets to jobs
@@ -30,6 +30,17 @@ jobs:
   hello:
     runs-on: ubuntu-latest
     permissions: {} # Set permissions
+    steps:
+      - run: echo hello
+```
+
+Or
+
+```yaml
+permissions: {} # Set permissions
+jobs:
+  hello:
+    runs-on: ubuntu-latest
     steps:
       - run: echo hello
 ```

--- a/pkg/cli/job_permissions_policy.go
+++ b/pkg/cli/job_permissions_policy.go
@@ -15,6 +15,9 @@ func (policy *JobPermissionsPolicy) Name() string {
 
 func (policy *JobPermissionsPolicy) Apply(ctx context.Context, logE *logrus.Entry, wf *Workflow) error {
 	failed := false
+	if wf.Permissions != nil && len(wf.Permissions) == 0 {
+		return nil
+	}
 	for jobName, job := range wf.Jobs {
 		if job.Permissions == nil {
 			failed = true

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -53,9 +53,10 @@ type Policy interface {
 }
 
 type Workflow struct {
-	FilePath string `yaml:"-"`
-	Jobs     map[string]*Job
-	Env      map[string]string
+	FilePath    string `yaml:"-"`
+	Jobs        map[string]*Job
+	Env         map[string]string
+	Permissions map[string]string
 }
 
 type Job struct {


### PR DESCRIPTION
e.g.

```yaml
permissions: {} # Set permissions
jobs:
  hello:
    runs-on: ubuntu-latest
    steps:
      - run: echo hello
```