### PR TITLE
fix: output errors regarding to configuration files

### DIFF
--- a/cmd/ghalint/main.go
+++ b/cmd/ghalint/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/suzuki-shunsuke/ghalint/pkg/cli"
+	"github.com/suzuki-shunsuke/ghalint/pkg/controller"
+	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
 var (
@@ -16,8 +20,14 @@ var (
 )
 
 func main() {
+	logE := logrus.NewEntry(logrus.New())
 	if err := core(); err != nil {
-		os.Exit(1)
+		hasLogLevel := &controller.HasLogLevelError{}
+		if errors.As(err, &hasLogLevel) {
+			logerr.WithError(logE, hasLogLevel.Err).Log(hasLogLevel.LogLevel, "ghalint failed")
+			os.Exit(1)
+		}
+		logerr.WithError(logE, err).Fatal("ghalint failed")
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,11 +27,15 @@ func (c *Controller) Run(ctx context.Context, logE *logrus.Entry) error {
 	cfg := &config.Config{}
 	if cfgFilePath := config.Find(c.fs); cfgFilePath != "" {
 		if err := config.Read(c.fs, cfg, cfgFilePath); err != nil {
-			return fmt.Errorf("read a configuration file: %w", err)
+			return fmt.Errorf("read a configuration file: %w", logerr.WithFields(err, logrus.Fields{
+				"config_file": cfgFilePath,
+			}))
 		}
-	}
-	if err := config.Validate(cfg); err != nil {
-		return fmt.Errorf("validate a configuration file: %w", err)
+		if err := config.Validate(cfg); err != nil {
+			return fmt.Errorf("validate a configuration file: %w", logerr.WithFields(err, logrus.Fields{
+				"config_file": cfgFilePath,
+			}))
+		}
 	}
 	filePaths, err := workflow.List(c.fs)
 	if err != nil {
@@ -55,7 +59,7 @@ func (c *Controller) Run(ctx context.Context, logE *logrus.Entry) error {
 		}
 	}
 	if failed {
-		return errors.New("some workflow files are invalid")
+		return debugError(errors.New("some workflow files are invalid"))
 	}
 	return nil
 }

--- a/pkg/controller/error.go
+++ b/pkg/controller/error.go
@@ -1,0 +1,23 @@
+package controller
+
+import "github.com/sirupsen/logrus"
+
+type HasLogLevelError struct {
+	LogLevel logrus.Level
+	Err      error
+}
+
+func (e *HasLogLevelError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *HasLogLevelError) Unwrap() error {
+	return e.Err
+}
+
+func debugError(err error) *HasLogLevelError {
+	return &HasLogLevelError{
+		LogLevel: logrus.DebugLevel,
+		Err:      err,
+	}
+}


### PR DESCRIPTION
Close #240

## Test

### Normal

```console
$ ghalint run
$ echo $?
0
```

### action_name is required

```yaml
excludes:
  - policy_name: action_ref_should_be_full_length_commit_sha
    # action_name: dorny/paths-filter
```

```console
$ ghalint run
FATA[0000] ghalint failed                                config_file=ghalint.yaml error="validate a configuration file: action_name is required to exclude action_ref_should_be_full_length_commit_sha"
```

### Have a lint error

```console
$ ghalint run             
ERRO[0000] action ref should be full length SHA1         job_name=release policy_name=action_ref_should_be_full_length_commit_sha program=ghalint uses=suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@v0.4.5 version= workflow_file_path=.github/workflows/release.yaml
```