### PR TITLE
feat(config): Find config files under the .github directory as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ghalint act foo/action.yaml bar/action.yml
 
 ## Configuration file
 
-Configuration file path: `^\.?ghalint\.ya?ml$`
+Configuration file path: `^(\.|\.github/)?ghalint\.ya?ml$`
 
 You can specify the configuration file with the command line option `-config (-c)` or the environment variable `GHALINT_CONFIG`.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,16 @@ func (e *Exclude) FilePath() string {
 }
 
 func Find(fs afero.Fs) string {
-	for _, filePath := range []string{"ghalint.yaml", ".ghalint.yaml", "ghalint.yml", ".ghalint.yml"} {
+	filePaths := []string{
+		"ghalint.yaml",
+		".ghalint.yaml",
+		".github/ghalint.yaml",
+		"ghalint.yml",
+		".ghalint.yml",
+		".github/ghalint.yml",
+	}
+
+	for _, filePath := range filePaths {
 		if _, err := fs.Stat(filePath); err == nil {
 			return filePath
 		}


### PR DESCRIPTION
Putting a config file under the `.github` directory is nice.

This is the same idea as pinact.
https://github.com/suzuki-shunsuke/pinact/blob/40cff4ad992d4c582e70ffdd3982c57e57796a14/pkg/config/config.go#L137-L148