### PR TITLE
feat: Add pre-commit hooks to validate workflow and action files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+---
+- id: ghalint
+  name: Validate GitHub Actions workflows
+  description: Check GitHub Actions workflows for security policy compliance
+  entry: ghalint run
+  language: golang
+  types: [yaml]
+  files: ^\.github/workflows/[^/]+\.ya?ml$
+
+- id: ghalint-act
+  name: Validate GitHub Actions
+  description: Check GitHub Actions for security policy compliance
+  entry: ghalint act
+  language: golang
+  types: [yaml]
+  files: ^([^/]+/){0,3}action\.ya?ml$


### PR DESCRIPTION
Users can run ghalint before committing or on CI.

- `ghalint`: Validate GitHub Actions workflow files (`^\.github/workflows/[^/]+\.ya?ml$`)
- `ghalint-act`: Validate GitHub Actions files (`^([^/]+/){0,3}action\.ya?ml$`)

```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/suzuki-shunsuke/ghalint
    rev: <tag/branch>
    hooks:
      - id: ghalint
      - id: ghalint-act
```

resolve #870