### PR TITLE
Add support for Docker references used by Renovate digest pinning

### DIFF
--- a/pkg/controller/act/run.go
+++ b/pkg/controller/act/run.go
@@ -28,7 +28,7 @@ func (c *Controller) Run(_ context.Context, logE *logrus.Entry, cfgFilePath stri
 		&policy.GitHubAppShouldLimitRepositoriesPolicy{},
 		&policy.GitHubAppShouldLimitPermissionsPolicy{},
 		&policy.ActionShellIsRequiredPolicy{},
-		policy.NewActionRefShouldBeSHA1Policy(),
+		policy.NewActionRefShouldBeSHAPolicy(),
 		&policy.CheckoutPersistCredentialShouldBeFalsePolicy{},
 	}
 	failed := false

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -31,14 +31,14 @@ func (c *Controller) Run(_ context.Context, logE *logrus.Entry, cfgFilePath stri
 		policy.NewJobSecretsPolicy(),
 		&policy.DenyInheritSecretsPolicy{},
 		&policy.DenyJobContainerLatestImagePolicy{},
-		policy.NewActionRefShouldBeSHA1Policy(),
+		policy.NewActionRefShouldBeSHAPolicy(),
 		&policy.DenyReadAllPermissionPolicy{},
 		&policy.DenyWriteAllPermissionPolicy{},
 	}
 	stepPolicies := []StepPolicy{
 		&policy.GitHubAppShouldLimitRepositoriesPolicy{},
 		&policy.GitHubAppShouldLimitPermissionsPolicy{},
-		policy.NewActionRefShouldBeSHA1Policy(),
+		policy.NewActionRefShouldBeSHAPolicy(),
 		&policy.CheckoutPersistCredentialShouldBeFalsePolicy{},
 	}
 	failed := false

--- a/pkg/policy/action_ref_should_be_full_length_commit_sha_policy.go
+++ b/pkg/policy/action_ref_should_be_full_length_commit_sha_policy.go
@@ -12,33 +12,33 @@ import (
 	"github.com/suzuki-shunsuke/logrus-error/logerr"
 )
 
-type ActionRefShouldBeSHA1Policy struct {
+type ActionRefShouldBeSHAPolicy struct {
 	sha1Pattern *regexp.Regexp
 }
 
-func NewActionRefShouldBeSHA1Policy() *ActionRefShouldBeSHA1Policy {
-	return &ActionRefShouldBeSHA1Policy{
+func NewActionRefShouldBeSHAPolicy() *ActionRefShouldBeSHAPolicy {
+	return &ActionRefShouldBeSHAPolicy{
 		sha1Pattern: regexp.MustCompile(`\b[0-9a-f]{40}\b`),
 	}
 }
 
-func (p *ActionRefShouldBeSHA1Policy) Name() string {
+func (p *ActionRefShouldBeSHAPolicy) Name() string {
 	return "action_ref_should_be_full_length_commit_sha"
 }
 
-func (p *ActionRefShouldBeSHA1Policy) ID() string {
+func (p *ActionRefShouldBeSHAPolicy) ID() string {
 	return "008"
 }
 
-func (p *ActionRefShouldBeSHA1Policy) ApplyJob(_ *logrus.Entry, cfg *config.Config, _ *JobContext, job *workflow.Job) error {
+func (p *ActionRefShouldBeSHAPolicy) ApplyJob(_ *logrus.Entry, cfg *config.Config, _ *JobContext, job *workflow.Job) error {
 	return p.apply(cfg, job.Uses)
 }
 
-func (p *ActionRefShouldBeSHA1Policy) ApplyStep(_ *logrus.Entry, cfg *config.Config, _ *StepContext, step *workflow.Step) error {
+func (p *ActionRefShouldBeSHAPolicy) ApplyStep(_ *logrus.Entry, cfg *config.Config, _ *StepContext, step *workflow.Step) error {
 	return p.apply(cfg, step.Uses)
 }
 
-func (p *ActionRefShouldBeSHA1Policy) apply(cfg *config.Config, uses string) error {
+func (p *ActionRefShouldBeSHAPolicy) apply(cfg *config.Config, uses string) error {
 	action := p.checkUses(uses)
 	if action == "" || p.excluded(action, cfg.Excludes) {
 		return nil
@@ -48,7 +48,7 @@ func (p *ActionRefShouldBeSHA1Policy) apply(cfg *config.Config, uses string) err
 	})
 }
 
-func (p *ActionRefShouldBeSHA1Policy) checkUses(uses string) string {
+func (p *ActionRefShouldBeSHAPolicy) checkUses(uses string) string {
 	if uses == "" {
 		return ""
 	}
@@ -62,7 +62,7 @@ func (p *ActionRefShouldBeSHA1Policy) checkUses(uses string) string {
 	return action
 }
 
-func (p *ActionRefShouldBeSHA1Policy) excluded(action string, excludes []*config.Exclude) bool {
+func (p *ActionRefShouldBeSHAPolicy) excluded(action string, excludes []*config.Exclude) bool {
 	for _, exclude := range excludes {
 		if exclude.PolicyName != p.Name() {
 			continue

--- a/pkg/policy/action_ref_should_be_full_length_commit_sha_policy.go
+++ b/pkg/policy/action_ref_should_be_full_length_commit_sha_policy.go
@@ -13,12 +13,14 @@ import (
 )
 
 type ActionRefShouldBeSHAPolicy struct {
-	sha1Pattern *regexp.Regexp
+	sha1Pattern   *regexp.Regexp
+	sha256Pattern *regexp.Regexp
 }
 
 func NewActionRefShouldBeSHAPolicy() *ActionRefShouldBeSHAPolicy {
 	return &ActionRefShouldBeSHAPolicy{
-		sha1Pattern: regexp.MustCompile(`\b[0-9a-f]{40}\b`),
+		sha1Pattern:   regexp.MustCompile(`\b[0-9a-f]{40}\b`),
+		sha256Pattern: regexp.MustCompile(`\b[0-9a-f]{64}\b`),
 	}
 }
 
@@ -43,7 +45,7 @@ func (p *ActionRefShouldBeSHAPolicy) apply(cfg *config.Config, uses string) erro
 	if action == "" || p.excluded(action, cfg.Excludes) {
 		return nil
 	}
-	return logerr.WithFields(errors.New("action ref should be full length SHA1"), logrus.Fields{ //nolint:wrapcheck
+	return logerr.WithFields(errors.New("action ref should be full length SHA"), logrus.Fields{ //nolint:wrapcheck
 		"action": action,
 	})
 }
@@ -51,6 +53,14 @@ func (p *ActionRefShouldBeSHAPolicy) apply(cfg *config.Config, uses string) erro
 func (p *ActionRefShouldBeSHAPolicy) checkUses(uses string) string {
 	if uses == "" {
 		return ""
+	}
+	if reference, ok := strings.CutPrefix(uses, "docker://"); ok {
+		rest, digest, ok := strings.Cut(reference, "@")
+		if ok && p.sha256Pattern.MatchString(digest) {
+			return ""
+		}
+		repository, _, _ := strings.Cut(rest, ":")
+		return "docker://" + repository
 	}
 	action, tag, ok := strings.Cut(uses, "@")
 	if !ok {

--- a/pkg/policy/action_ref_should_be_full_length_commit_sha_policy_test.go
+++ b/pkg/policy/action_ref_should_be_full_length_commit_sha_policy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/suzuki-shunsuke/ghalint/pkg/workflow"
 )
 
-func TestActionRefShouldBeSHA1Policy_ApplyJob(t *testing.T) {
+func TestActionRefShouldBeSHAPolicy_ApplyJob(t *testing.T) {
 	t.Parallel()
 	data := []struct {
 		name  string
@@ -48,7 +48,7 @@ func TestActionRefShouldBeSHA1Policy_ApplyJob(t *testing.T) {
 			},
 		},
 	}
-	p := policy.NewActionRefShouldBeSHA1Policy()
+	p := policy.NewActionRefShouldBeSHAPolicy()
 	logE := logrus.NewEntry(logrus.New())
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestActionRefShouldBeSHA1Policy_ApplyJob(t *testing.T) {
 	}
 }
 
-func TestActionRefShouldBeSHA1Policy_ApplyStep(t *testing.T) { //nolint:funlen
+func TestActionRefShouldBeSHAPolicy_ApplyStep(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	data := []struct {
 		name  string
@@ -124,7 +124,7 @@ func TestActionRefShouldBeSHA1Policy_ApplyStep(t *testing.T) { //nolint:funlen
 			},
 		},
 	}
-	p := policy.NewActionRefShouldBeSHA1Policy()
+	p := policy.NewActionRefShouldBeSHAPolicy()
 	logE := logrus.NewEntry(logrus.New())
 	for _, d := range data {
 		t.Run(d.name, func(t *testing.T) {

--- a/pkg/policy/action_ref_should_be_full_length_commit_sha_policy_test.go
+++ b/pkg/policy/action_ref_should_be_full_length_commit_sha_policy_test.go
@@ -47,6 +47,42 @@ func TestActionRefShouldBeSHAPolicy_ApplyJob(t *testing.T) {
 				Uses: "suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@v0.4.4",
 			},
 		},
+		{
+			name: "docker image with sha256 digest",
+			cfg:  &config.Config{},
+			job: &workflow.Job{
+				Uses: "docker://rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9",
+			},
+		},
+		{
+			name: "docker image with sha256 digest (no tag)",
+			cfg:  &config.Config{},
+			job: &workflow.Job{
+				Uses: "docker://rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9",
+			},
+		},
+		{
+			name:  "docker image with tag",
+			isErr: true,
+			cfg:   &config.Config{},
+			job: &workflow.Job{
+				Uses: "docker://rhysd/actionlint:latest",
+			},
+		},
+		{
+			name: "exclude docker image with tag",
+			cfg: &config.Config{
+				Excludes: []*config.Exclude{
+					{
+						PolicyName: "action_ref_should_be_full_length_commit_sha",
+						ActionName: "docker://rhysd/actionlint",
+					},
+				},
+			},
+			job: &workflow.Job{
+				Uses: "docker://rhysd/actionlint:latest",
+			},
+		},
 	}
 	p := policy.NewActionRefShouldBeSHAPolicy()
 	logE := logrus.NewEntry(logrus.New())
@@ -121,6 +157,42 @@ func TestActionRefShouldBeSHAPolicy_ApplyStep(t *testing.T) { //nolint:funlen
 				Uses: "slsa-framework/slsa-github-generator@v1.5.0",
 				ID:   "generate",
 				Name: "Generate SLSA Provenance",
+			},
+		},
+		{
+			name: "docker image with sha256 digest",
+			cfg:  &config.Config{},
+			step: &workflow.Step{
+				Uses: "docker://rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9",
+			},
+		},
+		{
+			name: "docker image with sha256 digest (no tag)",
+			cfg:  &config.Config{},
+			step: &workflow.Step{
+				Uses: "docker://rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9",
+			},
+		},
+		{
+			name:  "docker image with tag",
+			isErr: true,
+			cfg:   &config.Config{},
+			step: &workflow.Step{
+				Uses: "docker://rhysd/actionlint:latest",
+			},
+		},
+		{
+			name: "exclude docker image with tag",
+			cfg: &config.Config{
+				Excludes: []*config.Exclude{
+					{
+						PolicyName: "action_ref_should_be_full_length_commit_sha",
+						ActionName: "docker://rhysd/actionlint",
+					},
+				},
+			},
+			step: &workflow.Step{
+				Uses: "docker://rhysd/actionlint:latest",
 			},
 		},
 	}


### PR DESCRIPTION
## Description
This PR allows `docker://{repository}:{tag}@{digest}` format (used by [Renovate](https://github.com/renovatebot/renovate) for [digest pinning](https://docs.renovatebot.com/docker/#digest-pinning)) to pass validation, in addition to the previously supported `docker://{repository}@{digest} # {tag}` format.

## Background
When using CLI tools like [actionlint](https://github.com/rhysd/actionlint) or [zizmor](https://github.com/zizmorcore/zizmor) in GitHub Actions, it's convenient to specify container images in the format `docker://{repository}:{tag}@{digest}`. This format is compatible with [Renovate](https://github.com/renovatebot/renovate)'s [digest pinning](https://docs.renovatebot.com/docker/#digest-pinning), which allows both the tag and digest to be kept in sync when new versions are released—ensuring reproducibility while still staying up to date.

However, in `ghalint` v1.4.0, using this format results in an error—even though the reference is fully pinned and valid.

## Example Error Output (Before Fix)
```console
$ ghalint run
ERRO[0000] the step violates policies                    action="docker://rhysd/actionlint:1.7.7" error="action ref should be full length SHA1" job_name=actionlint policy_name=action_ref_should_be_full_length_commit_sha program=ghalint reference="https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/008.md" step_name="Run actionlint" version=1.3.0 workflow_file_path=.github/workflows/example.yaml
ERRO[0000] the step violates policies                    action="docker://ghcr.io/woodruffw/zizmor:1.7.0" error="action ref should be full length SHA1" job_name=zizmor policy_name=action_ref_should_be_full_length_commit_sha program=ghalint reference="https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/008.md" step_name="Run zizmor" version=1.3.0 workflow_file_path=.github/workflows/example.yaml
```

<details>
<summary>.github/workflows/example.yaml</summary>

```yaml
name: Example
on:
  pull_request:
    paths:
      - .github/workflows/**
permissions: {}
jobs:
  actionlint:
    name: actionlint
    runs-on: ubuntu-latest
    timeout-minutes: 60
    permissions:
      contents: read
    steps:
      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
        with:
          persist-credentials: false
      - name: Add problem matchers
        run: echo "::add-matcher::.github/actionlint-matcher.json"
      - name: Run actionlint
        uses: docker://rhysd/actionlint:1.7.7@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9
        with:
          args: -color
  ghalint:
    name: ghalint
    runs-on: ubuntu-latest
    timeout-minutes: 60
    permissions:
      contents: read
    steps:
      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
        with:
          persist-credentials: false
      - name: Set up ghalint
        env:
          GHALINT_VERSION: v1.4.0
          GH_TOKEN: ${{ github.token }}
        run: |
          TMPDIR=$(mktemp -d)
          gh release download "$GHALINT_VERSION" -R suzuki-shunsuke/ghalint -p "ghalint_*_linux_amd64.tar.gz" -O "$TMPDIR/ghalint.tar.gz"
          gh attestation verify "$TMPDIR/ghalint.tar.gz" -R suzuki-shunsuke/ghalint --signer-workflow suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
          tar -C /usr/local/bin -xzf "$TMPDIR/ghalint.tar.gz"
      - name: Run ghalint
        run: ghalint run
  zizmor:
    name: zizmor
    runs-on: ubuntu-latest
    timeout-minutes: 60
    permissions:
      contents: read
    steps:
      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
        with:
          persist-credentials: false
      - name: Run zizmor
        uses: docker://ghcr.io/woodruffw/zizmor:1.7.0@sha256:3d53be4e0f48952112aa4ca00f45e724b70598082e7202c5c412a6779ca38134
        env:
          GH_TOKEN: ${{ github.token }}
        with:
          args: -p --format=github --min-severity=low .github/workflows
```
</details>

## Reference
- [renovatebot/renovate#25276 – Support Docker uses in GitHub Actions](https://github.com/renovatebot/renovate/issues/25276)
