### PR TITLE
docs: Add docstring for public constant KeyService

### DIFF
--- a/pkg/github/keyring.go
+++ b/pkg/github/keyring.go
@@ -1,5 +1,6 @@
 package github
 
 const (
+	// KeyService defines the service name for GitHub keyring used by ghalint.
 	KeyService = "suzuki-shunsuke/ghalint"
 )


### PR DESCRIPTION
This pull request adds a documentation comment to a public constant to improve code clarity and maintainability.

**Problem:**
The public constant `KeyService` in `pkg/github/keyring.go` lacked a docstring. This omission reduced code readability and made it harder for other developers to understand its purpose without examining the codebase further.

**Change:**
A comment has been added above the `KeyService` constant definition. The comment clearly states that it defines the service name for the GitHub keyring used by the `ghalint` tool. This aligns with Go documentation conventions for exported symbols.

**Verification:**
1. The code compiles successfully (`go build ./...`).
2. No functional behavior is altered; this is a documentation-only change.
3. The change can be reviewed by examining the diff in `pkg/github/keyring.go`.