### PR TITLE
feat: support ** globs in action_name excludes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,8 +95,8 @@ func validate(exclude *Exclude) error { //nolint:cyclop
 		if exclude.ActionName == "" {
 			return errors.New(`action_name is required to exclude action_ref_should_be_full_length_commit_sha`)
 		}
-		if _, err := path.Match(exclude.ActionName, ""); err != nil {
-			return fmt.Errorf("action_name must be a glob pattern: %w", slogerr.With(err, "pattern_reference", "https://pkg.go.dev/path#Match"))
+		if _, err := MatchActionName(exclude.ActionName, ""); err != nil {
+			return fmt.Errorf("action_name must be a glob pattern: %w", slogerr.With(err, "pattern_reference", "https://pkg.go.dev/path#Match (plus ** across /)"))
 		}
 	case "job_secrets":
 		if exclude.WorkflowFilePath == "" {

--- a/pkg/config/match.go
+++ b/pkg/config/match.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+// MatchActionName matches an action name against an exclude pattern.
+//
+// Patterns use the same rules as path.Match, and additionally support "**"
+// which matches across path separators (including zero segments). This lets
+// excludes like "my-org/actions/**" cover nested composite actions.
+func MatchActionName(pattern, name string) (bool, error) {
+	if !strings.Contains(pattern, "**") {
+		return path.Match(pattern, name)
+	}
+	re, err := doublestarToRegexp(pattern)
+	if err != nil {
+		return false, err
+	}
+	return re.MatchString(name), nil
+}
+
+func doublestarToRegexp(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteByte('^')
+	for i := 0; i < len(pattern); {
+		if i+1 < len(pattern) && pattern[i] == '*' && pattern[i+1] == '*' {
+			b.WriteString(".*")
+			i += 2
+			if i < len(pattern) && pattern[i] == '/' {
+				// "**/" also absorbs the following slash so "a/**/b" works.
+				i++
+			}
+			continue
+		}
+		switch c := pattern[i]; c {
+		case '*':
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		case '.', '+', '(', ')', '|', '^', '$', '{', '}', '[', ']', '\':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
+		}
+		i++
+	}
+	b.WriteByte('$')
+	return regexp.Compile(b.String())
+}

--- a/pkg/config/match_test.go
+++ b/pkg/config/match_test.go
@@ -1,0 +1,36 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/suzuki-shunsuke/ghalint/pkg/config"
+)
+
+func TestMatchActionName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		pattern string
+		name    string
+		want    bool
+	}{
+		{"my-org/actions/*", "my-org/actions/setup", true},
+		{"my-org/actions/*", "my-org/actions/setup/node", false},
+		{"my-org/actions/**", "my-org/actions/setup", true},
+		{"my-org/actions/**", "my-org/actions/setup/node", true},
+		{"my-org/actions/**", "my-org/actions/a/b/c", true},
+		{"my-org/actions/**", "other/actions/setup", false},
+		{"docker://rhysd/actionlint", "docker://rhysd/actionlint", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pattern+"::"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := config.MatchActionName(tc.pattern, tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/policy/action_ref_should_be_full_length_commit_sha_policy.go
+++ b/pkg/policy/action_ref_should_be_full_length_commit_sha_policy.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"errors"
 	"log/slog"
-	"path"
 	"regexp"
 	"strings"
 
@@ -82,7 +81,7 @@ func (p *ActionRefShouldBeSHAPolicy) excluded(action string, excludes []*config.
 		if exclude.PolicyName != p.Name() {
 			continue
 		}
-		if f, _ := path.Match(exclude.ActionName, action); f {
+		if f, err := config.MatchActionName(exclude.ActionName, action); err == nil && f {
 			return true
 		}
 	}

--- a/pkg/policy/action_ref_should_be_full_length_commit_sha_policy_test.go
+++ b/pkg/policy/action_ref_should_be_full_length_commit_sha_policy_test.go
@@ -158,6 +158,20 @@ func TestActionRefShouldBeSHAPolicy_ApplyStep(t *testing.T) { //nolint:funlen
 			},
 		},
 		{
+			name: "exclude with double-star glob",
+			cfg: &config.Config{
+				Excludes: []*config.Exclude{
+					{
+						PolicyName: "action_ref_should_be_full_length_commit_sha",
+						ActionName: "my-private-org/actions/**",
+					},
+				},
+			},
+			step: &workflow.Step{
+				Uses: "my-private-org/actions/setup/node@v1",
+			},
+		},
+		{
 			name: "exclude with glob pattern",
 			cfg: &config.Config{
 				Excludes: []*config.Exclude{


### PR DESCRIPTION
## Summary
`action_name` exclude patterns now support `**`, which matches across `/`.

```yaml
excludes:
  - policy_name: action_ref_should_be_full_length_commit_sha
    action_name: my-private-org/actions/**
```

covers nested composite actions without listing `*`, `*/*`, `*/*/*`, …

Existing `path.Match` patterns keep working unchanged.

Fixes #1354

## Test plan
- [ ] `go test ./pkg/config/ ./pkg/policy/ -count=1`
- [ ] Config with `my-org/actions/**` excludes `my-org/actions/setup/node@v1`
